### PR TITLE
Added CMake-based build for Saleae under Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.14...3.22)
+
+project(
+  QSPI_Analyzer
+  VERSION 1.0
+  LANGUAGES CXX
+)
+
+set(AnalyzerSDK_DIR SaleaeAnalyzerSDK)
+find_package(AnalyzerSDK REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED
+    src/QSpiAnalyzer.cpp
+    src/QSpiAnalyzer.h
+    src/QSpiAnalyzerResults.cpp
+    src/QSpiAnalyzerResults.h
+    src/QSpiAnalyzerSettings.cpp
+    src/QSpiAnalyzerSettings.h
+    src/QSpiDataChannelManager.cpp
+    src/QSpiDataChannelManager.h
+    src/QSpiSimulationDataGenerator.cpp
+    src/QSpiSimulationDataGenerator.h
+    src/QspiTypes.h
+    src/QSpiUtil.h
+)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
+target_link_libraries(${PROJECT_NAME} PUBLIC Saleae::AnalyzerSDK)
+target_compile_definitions(${PROJECT_NAME} PRIVATE SOFTWARE_VER=Saleae)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,4 +25,4 @@ add_library(${PROJECT_NAME} SHARED
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
 target_link_libraries(${PROJECT_NAME} PUBLIC Saleae::AnalyzerSDK)
-target_compile_definitions(${PROJECT_NAME} PRIVATE SOFTWARE_VER=Saleae)
+target_compile_definitions(${PROJECT_NAME} PRIVATE SALEAE_ANALYZER)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ Analyzer for low level debugging of the QSPI Protocol, for use with Saleae and K
 ## Building/Debugging
 ---
 **Note:** Saleae users must also run `git submodule update --init --recursive` to download the [Saleae Analyzer SDK][asdk].
+
+
+
+
+**Building with CMake**
+1) For Windows - simply open `Visual Studio`->`Continue Without Code`->`File`->`Open`->`CMake` and select the corresponding CMakeLists.txt from the project folder. Then just select the target configuration(Release or Debug x64) and build it.
+2) For Linux, execute the following in the cloned repository folder
+```shell
+mkdir build && cd build
+cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
+```
+Then just copy `libQSPI_Analyzer.so` to the directory where you'd like to store Saleae plugins.
+
+
 #### Windows
 
 **Building**

--- a/src/QSpiAnalyzer.h
+++ b/src/QSpiAnalyzer.h
@@ -1,9 +1,9 @@
 #ifndef QSPI_ANALYZER_H
 #define QSPI_ANALYZER_H
 
-#if SOFTWARE_VER == SALEAE
+#ifdef SALEAE_ANALYZER
 #define ANALYZER_VERSION Analyzer2
-#elif SOFTWARE_VER == KINGSTVIS
+#elif KINGSTVIS_ANALYZER
 #define ANALYZER_VERSION Analyzer
 #else
 #error Not supported or undefined


### PR DESCRIPTION
Hello. Thanks for your analyzer plugin. Unfortunately, it seems that the build of .sln is broken, since it uses absolute paths to the sources. I've tried to rewrite the recipe of the project to CMake and test it under Windows and Saleae 2. Seems it works:
![image](https://github.com/AddioElectronics/QSPI-Analyzer/assets/25596072/3672b4a9-b58b-473b-b20f-b8e91827028f)

Build logs from Visual Studio solution:
```log
>------ Build started: Project: CMakeLists, Configuration: Release ------
  [1/6] Building CXX object CMakeFiles\QSPI_Analyzer.dir\src\QSpiDataChannelManager.cpp.obj
  [2/6] Building CXX object CMakeFiles\QSPI_Analyzer.dir\src\QSpiSimulationDataGenerator.cpp.obj
  [3/6] Building CXX object CMakeFiles\QSPI_Analyzer.dir\src\QSpiAnalyzer.cpp.obj
  [4/6] Building CXX object CMakeFiles\QSPI_Analyzer.dir\src\QSpiAnalyzerSettings.cpp.obj
  [5/6] Building CXX object CMakeFiles\QSPI_Analyzer.dir\src\QSpiAnalyzerResults.cpp.obj
  [6/6] Linking CXX shared library QSPI_Analyzer.dll

Build succeeded.
```
P.S. I've been trying to debug STM32 OSPI in QSPI mode, so your analyzer will be useful.
