### PR TITLE
Added option for ignoring initial CLK state

### DIFF
--- a/src/QSpiAnalyzer.cpp
+++ b/src/QSpiAnalyzer.cpp
@@ -15,6 +15,10 @@ QSpiAnalyzer::QSpiAnalyzer()
         mCs(NULL)
 {
     SetAnalyzerSettings(mSettings.get()); 
+
+#if defined(LOGIC2) && (SOFTWARE == SALEAE)
+    UseFrameV2();
+#endif
 }
 
 QSpiAnalyzer::~QSpiAnalyzer()
@@ -346,6 +350,37 @@ void QSpiAnalyzer::GetBlock()
     result_frame.mType = (U8)mTransactionState;
 
     mResults->AddFrame(result_frame);
+
+#if defined(LOGIC2) && (SOFTWARE == SALEAE)
+    FrameV2 frame_v2;
+    const char* state_str;
+    switch (mTransactionState)
+    {
+        case QSpiTypes::SETUP_STATE:
+            state_str = "SETUP";
+            break;
+        case QSpiTypes::COMMAND_STATE:
+            state_str = "COMMAND";
+            break;
+        case QSpiTypes::ADDRESS_STATE:
+            state_str = "ADDRESS";
+            break;
+        case QSpiTypes::DUMMY_STATE:
+            state_str = "DUMMY";
+            break;
+        case QSpiTypes::DATA_STATE:
+            state_str = "DATA";
+            break;
+        default:
+            state_str = "UNDEFINED";
+            break;
+    }
+
+    frame_v2.AddInteger("data", data_word);
+    frame_v2.AddString("state", state_str);
+    mResults->AddFrameV2(frame_v2, "data_byte", result_frame.mStartingSampleInclusive, result_frame.mEndingSampleInclusive);
+#endif
+
     mResults->CommitResults();
 
     if (advancing){

--- a/src/QSpiAnalyzer.cpp
+++ b/src/QSpiAnalyzer.cpp
@@ -154,7 +154,7 @@ void QSpiAnalyzer::AdvanceToActiveEnableEdge()
 
 bool QSpiAnalyzer::IsInitialClockPolarityCorrect()
 {
-    if (mSck->GetBitState() == mSettings->mClockIdle) {
+    if (mSck->GetBitState() == mSettings->mClockIdle || mSettings->mIgnoreInitialClkState) {
         return true;
     }
 

--- a/src/QSpiAnalyzer.cpp
+++ b/src/QSpiAnalyzer.cpp
@@ -154,7 +154,11 @@ void QSpiAnalyzer::AdvanceToActiveEnableEdge()
 
 bool QSpiAnalyzer::IsInitialClockPolarityCorrect()
 {
-    if (mSck->GetBitState() == mSettings->mClockIdle || mSettings->mIgnoreInitialClkState) {
+    if (mSck->GetBitState() == mSettings->mClockIdle) {
+        return true;
+    }
+    else if (mSettings->mIgnoreInitialClkState) {
+        mSck->AdvanceToNextEdge();
         return true;
     }
 

--- a/src/QSpiAnalyzerSettings.cpp
+++ b/src/QSpiAnalyzerSettings.cpp
@@ -151,6 +151,11 @@ QSpiAnalyzerSettings::QSpiAnalyzerSettings()
     mDataRateInterface->AddNumber(QSpiTypes::DDR, "DDR", "");
     mDataRateInterface->SetNumber(mDataRate);
 
+    mIgnoreInitialClkStateInterface.reset(new AnalyzerSettingInterfaceBool());
+    mIgnoreInitialClkStateInterface->SetTitleAndTooltip("", "Ignore initial CS/CLK state");
+    mIgnoreInitialClkStateInterface->SetCheckBoxText("Ignore initial CLK state");
+    mIgnoreInitialClkStateInterface->SetValue(mIgnoreInitialClkState);
+
     mUseShowMarkerInterface.reset(new AnalyzerSettingInterfaceBool());
     mUseShowMarkerInterface->SetTitleAndTooltip("", "Show decode marker or not");
     mUseShowMarkerInterface->SetCheckBoxText("Show Decode Marker");
@@ -180,6 +185,8 @@ QSpiAnalyzerSettings::QSpiAnalyzerSettings()
 
     AddInterface(mCsPreEnabledInterface.get());
     AddInterface(mCsPostEnabledInterface.get());
+
+    AddInterface(mIgnoreInitialClkStateInterface.get());
 
     AddInterface(mUseShowMarkerInterface.get());
 
@@ -258,6 +265,8 @@ bool QSpiAnalyzerSettings::SetSettingsFromInterfaces()
 
     mCsPreCycles = mCsPreEnabledInterface->GetNumber();
     mCsPostCycles = mCsPostEnabledInterface->GetNumber();
+
+    mIgnoreInitialClkState = mIgnoreInitialClkStateInterface->GetValue();
 
     mShowMarker = mUseShowMarkerInterface->GetValue();
 
@@ -394,6 +403,8 @@ void QSpiAnalyzerSettings::UpdateInterfacesFromSettings()
     mDataRateInterface->SetNumber(mDataRate);
     mCsPreEnabledInterface->SetNumber(mCsPreCycles);
     mCsPostEnabledInterface->SetNumber(mCsPostCycles);
+
+    mIgnoreInitialClkStateInterface->SetValue(mIgnoreInitialClkState);
 
     mUseShowMarkerInterface->SetValue(mShowMarker);
 }

--- a/src/QSpiAnalyzerSettings.h
+++ b/src/QSpiAnalyzerSettings.h
@@ -61,6 +61,7 @@ public:
 
     U32 mCsPreCycles;
     U32 mCsPostCycles;
+    bool  mIgnoreInitialClkState;
     bool  mShowMarker;
 
 protected:
@@ -90,6 +91,7 @@ protected:
 	std::unique_ptr< AnalyzerSettingInterfaceNumberList > mCsPreEnabledInterface;
 	std::unique_ptr< AnalyzerSettingInterfaceNumberList > mCsPostEnabledInterface;
 
+    std::unique_ptr< AnalyzerSettingInterfaceBool > mIgnoreInitialClkStateInterface;
 
     std::unique_ptr< AnalyzerSettingInterfaceBool > mUseShowMarkerInterface;
 };


### PR DESCRIPTION
Hello.

Sometimes it's necessary to analyze data when CLK and CS can be toggles simultaneously (which can cause rejection of such transactions by this analyzer). I can't do anything with it as it hardware specific behavior, but I added option to accept such captures.